### PR TITLE
メッセージ内容がないときにOutOfRangeが発生する問題を修正

### DIFF
--- a/Script/Utility/Dice.cs
+++ b/Script/Utility/Dice.cs
@@ -20,7 +20,7 @@ namespace PriconneBotConsoleApp.Script
             var splitMessage = m_UserMessage.Content.ZenToHan().Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var diceMax = UtilityDefine.DefaultMaxDiceNumber;
 
-            if (splitMessage[0] != "!dice")
+            if (splitMessage.Length == 0 || splitMessage[0] != "!dice")
             {
                 return;
             }


### PR DESCRIPTION
画像をそのまま送信した際にMessage内容がないので、splitMessage.length = 0 になってOutOfRangeになる