### PR TITLE
JetBrains Riderが自動生成するファイルをIgnoreしたい

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,26 +367,28 @@ FodyWeavers.xsd
 # Sourece https://github.com/JetBrains/resharper-rider-samples/blob/master/.gitignore
 # Common IntelliJ Platform excludes
 
+**/.idea/
+
 # User specific
-**/.idea/**/workspace.xml
-**/.idea/**/tasks.xml
-**/.idea/shelf/*
-**/.idea/dictionaries
-**/.idea/httpRequests/
+# **/.idea/**/workspace.xml
+# **/.idea/**/tasks.xml
+# **/.idea/shelf/*
+# **/.idea/dictionaries
+# **/.idea/httpRequests/
 
 # Sensitive or high-churn files
-**/.idea/**/dataSources/
-**/.idea/**/dataSources.ids
-**/.idea/**/dataSources.xml
-**/.idea/**/dataSources.local.xml
-**/.idea/**/sqlDataSources.xml
-**/.idea/**/dynamic.xml
+# **/.idea/**/dataSources/
+# **/.idea/**/dataSources.ids
+# **/.idea/**/dataSources.xml
+# **/.idea/**/dataSources.local.xml
+# **/.idea/**/sqlDataSources.xml
+# **/.idea/**/dynamic.xml
 
 # Rider
 # Rider auto-generates .iml files, and contentModel.xml
-**/.idea/**/*.iml
-**/.idea/**/contentModel.xml
-**/.idea/**/modules.xml
+# **/.idea/**/*.iml
+# **/.idea/**/contentModel.xml
+# **/.idea/**/modules.xml
 
 Thumbs.db
 Desktop.ini


### PR DESCRIPTION
現状ではRiderが自動生成する設定ファイル群をわざわざコミットから除外する必要があり面倒なので、.gitignoreで除外してしまいたい

@ca45382 がRiderを導入したらこのPRをRevertして、Rider用の設定ファイルをリポジトリ管理にしてもいいかもしれない