### PR TITLE
既に来ているボスにも予約ができるように対応

### DIFF
--- a/Script/ClanBattle/BattleReservation.cs
+++ b/Script/ClanBattle/BattleReservation.cs
@@ -53,11 +53,6 @@ namespace PriconneBotConsoleApp.Script
 
             var allowMinReservationLap = m_CommandEventArgs.ClanData.GetBossLap(reservationData.BossNumber);
 
-            //var allowMinReservationLap = Math.Min(
-            //        m_CommandEventArgs.ClanData.GetBossLap(reservationData.BossNumber) + 1,
-            //        m_CommandEventArgs.ClanData.GetMinBossLap() + CommonDefine.BattleLapRange + 1
-            //    );
-
             if (reservationData.BattleLap < allowMinReservationLap)
             {
                 _ = m_CommandEventArgs.Channel.SendTimedMessageAsync(

--- a/Script/ClanBattle/BattleReservation.cs
+++ b/Script/ClanBattle/BattleReservation.cs
@@ -51,10 +51,12 @@ namespace PriconneBotConsoleApp.Script
                 return;
             }
 
-            var allowMinReservationLap = Math.Min(
-                    m_CommandEventArgs.ClanData.GetBossLap(reservationData.BossNumber) + 1,
-                    m_CommandEventArgs.ClanData.GetMinBossLap() + CommonDefine.BattleLapRange + 1
-                );
+            var allowMinReservationLap = m_CommandEventArgs.ClanData.GetBossLap(reservationData.BossNumber);
+
+            //var allowMinReservationLap = Math.Min(
+            //        m_CommandEventArgs.ClanData.GetBossLap(reservationData.BossNumber) + 1,
+            //        m_CommandEventArgs.ClanData.GetMinBossLap() + CommonDefine.BattleLapRange + 1
+            //    );
 
             if (reservationData.BattleLap < allowMinReservationLap)
             {


### PR DESCRIPTION
#134 で既に来ているボスに対しては予約をできないように変更したが、以下の理由から既に来ているボスに対して予約をできるように変更した

- 2周先のボスと段階をまたぐ場合のボスに対して予約をできるように対応するのが難しい
- 来ているボスにも予約できるようにしてほしいとの声があった